### PR TITLE
Added "--" between run and args

### DIFF
--- a/listings/ch12-an-io-project/listing-12-12/output.txt
+++ b/listings/ch12-an-io-project/listing-12-12/output.txt
@@ -1,4 +1,4 @@
-$ cargo run the poem.txt
+$ cargo run -- the poem.txt
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
 warning: unused `Result` that must be used
   --> src/main.rs:19:5


### PR DESCRIPTION
In Chapter 12.3 the command to run is missing the "--" to separe cargo commands from bin arguments.